### PR TITLE
ARC-AGI: Completely separate train/test examples at puzzle level

### DIFF
--- a/dataset/common.py
+++ b/dataset/common.py
@@ -49,3 +49,27 @@ def dihedral_transform(arr: np.ndarray, tid: int) -> np.ndarray:
     
 def inverse_dihedral_transform(arr: np.ndarray, tid: int) -> np.ndarray:
     return dihedral_transform(arr, DIHEDRAL_INVERSE[tid])
+
+
+def split_puzzles_by_id(puzzle_ids: List[str], test_fraction: float = 0.2, seed: int = 42) -> tuple[set[str], set[str]]:
+    """Split puzzle IDs into train and test sets to avoid data leakage.
+    
+    Args:
+        puzzle_ids: List of puzzle identifiers
+        test_fraction: Fraction of puzzles to reserve for testing
+        seed: Random seed for reproducible splits
+        
+    Returns:
+        Tuple of (train_puzzle_ids, test_puzzle_ids)
+    """
+    import random
+    random.seed(seed)
+    
+    shuffled_ids = puzzle_ids.copy()
+    random.shuffle(shuffled_ids)
+    
+    num_test = int(len(shuffled_ids) * test_fraction)
+    test_ids = set(shuffled_ids[:num_test])
+    train_ids = set(shuffled_ids[num_test:])
+    
+    return train_ids, test_ids


### PR DESCRIPTION
# What

- An attempt to remove Test-Time Training and completely resolve the issue #18 

# Description

I saw #18 and was interested in how the model would behave in ARC-AGI if it only used puzzle inputs/outputs from `train` instead of also incorporating the inputs from `test`. 

**While I know that TTT is allowed in ARC-AGI**, training on `test` examples beforehand does allow the model to have an unfair understanding of the implied rules used in them. It would be interesting to see how the _H&L_ arch could figure out the implied rules it has not seen before, just like humans. 

By removing TTT your model's evaluation result on ARC-AGI can be more convincing and more indicative of the model's actual generalization abilities.